### PR TITLE
Fix argument parsing bug in rebasepro

### DIFF
--- a/rebasepro/rebasepro
+++ b/rebasepro/rebasepro
@@ -2,7 +2,7 @@
 ACTION=""
 args=("$@")
 
-for idx in {1..$#args}; do
+for ((idx=1; idx <= $#args; idx++)); do
   if [[ "${args[idx]}" == "--" ]]; then
     next_idx=$((idx + 1))
     ACTION="${args[next_idx]}"


### PR DESCRIPTION
## Summary
- ensure rebasepro correctly iterates over provided args when parsing for `--`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fa886fc84832ca5b152ebd41f8e05