### PR TITLE
Fix choose-root-branch sed portability

### DIFF
--- a/rebasepro/choose-root-branch
+++ b/rebasepro/choose-root-branch
@@ -36,7 +36,7 @@ if [[ "$FORCE_RESELECT" == true || -z "$ROOT_BRANCH" ]]; then
 
    # Update or add to config file
   if grep -q '^ROOT_BRANCH=' "$CONFIG_FILE"; then
-    sed -i '' "s|^ROOT_BRANCH=.*|ROOT_BRANCH=$ROOT_BRANCH|" "$CONFIG_FILE"
+    sed -i.bak "s|^ROOT_BRANCH=.*|ROOT_BRANCH=$ROOT_BRANCH|" "$CONFIG_FILE" && rm -f "$CONFIG_FILE.bak"
     echo "ROOT_BRANCH updated to $ROOT_BRANCH"
   else
     echo "ROOT_BRANCH=$ROOT_BRANCH" >> "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- update `choose-root-branch` to use `sed -i.bak` and remove backup

## Testing
- `bash rebasepro/choose-root-branch --reset` (with stubbed `gum` command)

------
https://chatgpt.com/codex/tasks/task_e_683faa829e3c832ca189da9f4635b868